### PR TITLE
Update Readme.md to clarify effect

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,12 +8,12 @@ Emits events from streams in series.
 var series = require('stream-series');
 var orderedStream = series(streamA, streamC, streamB);
 
-streamA.end('a');
-streamB.end('b');
 streamC.end('c');
+streamB.end('b');
+streamA.end('a');
 
 var writer = es.writeArray(function(err, array) {
-  // Array will be ['a', 'c', 'b'];
+  // Array will be ['a', 'c', 'b'] even though streams sent data in reverse order;
 });
 
 orderedStream.pipe(writer);


### PR DESCRIPTION
Right now the example doesn't show the effect that your module has on the stream.  The output would be ordered that way even if you used something like the `merge-stream` module.
